### PR TITLE
For zip function, set JSZip type option to nodebuffer if in node environment

### DIFF
--- a/src/zip.js
+++ b/src/zip.js
@@ -4,7 +4,7 @@ var write = require('./write'),
     JSZip = require('jszip');
 
 module.exports = function(gj, options) {
-    
+
     var zip = new JSZip(),
         layers = zip.folder(options && options.folder ? options.folder : 'layers');
 
@@ -28,5 +28,11 @@ module.exports = function(gj, options) {
         }
     });
 
-    return zip.generate({compression:'STORE'});
+    var generateOptions = { compression:'STORE' };
+
+    if (typeof window === 'undefined') {
+      generateOptions.type = 'nodebuffer';
+    }
+
+    return zip.generate(generateOptions);
 };

--- a/src/zip.js
+++ b/src/zip.js
@@ -30,7 +30,7 @@ module.exports = function(gj, options) {
 
     var generateOptions = { compression:'STORE' };
 
-    if (typeof window === 'undefined') {
+    if (!process.browser) {
       generateOptions.type = 'nodebuffer';
     }
 


### PR DESCRIPTION
I was getting strange *.cpgz files after using this library's zip function to create shapefiles in a node environment, which I'm assuming is because the default zip type for JSZip [is base64](https://stuk.github.io/jszip/documentation/api_jszip/generate.html). This PR checks to see if you're running in a node environment, and if so changes the type to `'nodebuffer'`.