### PR TITLE
bugfix(zip): fix check for feature type presence

### DIFF
--- a/src/zip.js
+++ b/src/zip.js
@@ -10,7 +10,7 @@ module.exports = function(gj, options) {
 
     [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
         .forEach(function(l) {
-        if (l.geometries[0].length) {
+        if (l.geometries.length && l.geometries[0].length) {
             write(
                 // field definitions
                 l.properties,

--- a/src/zip.js
+++ b/src/zip.js
@@ -10,7 +10,7 @@ module.exports = function(gj, options) {
 
     [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
         .forEach(function(l) {
-        if (l.geometries.length) {
+        if (l.geometries[0].length) {
             write(
                 // field definitions
                 l.properties,


### PR DESCRIPTION
the geojson.line(features) call on a feature collection that does not
contain any line features returns an empty array nested inside an array
causing the l.geometries.length to always return true, which causes and
attempt to pefrorm a write on an empty array of geometries, which causes
the write call to never return, and thus keeps the zip function from finishing.

this is avoided by checking the length of the nested array instead.

fixes #43 