### PR TITLE
Do not put a folder in zip to improve interoperability

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Or in a browser
 ```js
 var shpwrite = require('shp-write');
 
-// (optional) set names for feature types and zipped folder
+// (optional) set names for feature types
 var options = {
-    folder: 'myshapes',
     types: {
         point: 'mypoints',
         polygon: 'mypolygons',

--- a/src/zip.js
+++ b/src/zip.js
@@ -5,8 +5,7 @@ var write = require('./write'),
 
 module.exports = function(gj, options) {
 
-    var zip = new JSZip(),
-        layers = zip.folder(options && options.folder ? options.folder : 'layers');
+    var zip = new JSZip();
 
     [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
         .forEach(function(l) {
@@ -20,10 +19,10 @@ module.exports = function(gj, options) {
                 l.geometries,
                 function(err, files) {
                     var fileName = options && options.types[l.type.toLowerCase()] ? options.types[l.type.toLowerCase()] : l.type;
-                    layers.file(fileName + '.shp', files.shp.buffer, { binary: true });
-                    layers.file(fileName + '.shx', files.shx.buffer, { binary: true });
-                    layers.file(fileName + '.dbf', files.dbf.buffer, { binary: true });
-                    layers.file(fileName + '.prj', prj);
+                    zip.file(fileName + '.shp', files.shp.buffer, { binary: true });
+                    zip.file(fileName + '.shx', files.shx.buffer, { binary: true });
+                    zip.file(fileName + '.dbf', files.dbf.buffer, { binary: true });
+                    zip.file(fileName + '.prj', prj);
                 });
         }
     });


### PR DESCRIPTION
We had some trouble reading shapefiles generated from shp-write. Just putting everything into the zip without subfolders fixed this.