### PR TITLE
Allow configuration of type when zipping

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -1,6 +1,7 @@
 var zip = require('./zip');
 
 module.exports = function(gj, options) {
-    var content = zip(gj, options);
-    location.href = 'data:application/zip;base64,' + content;
-};
+    zip(gj, options).then(function(content) {
+      location.href = 'data:application/zip;base64,' + content;
+    });
+  };

--- a/src/zip.js
+++ b/src/zip.js
@@ -15,7 +15,7 @@ module.exports = function(gj, options, generateOptions) {
                 // field definitions
                 l.properties,
                 // geometry type
-                l.type, 
+                l.type,
                 // geometries
                 l.geometries,
                 function(err, files) {
@@ -28,15 +28,15 @@ module.exports = function(gj, options, generateOptions) {
         }
     });
 
-    if (generateOptions){
+    if (generateOptions) {
         generateOptions.compression = 'STORE';
-    }else{
-        generateOptions = { compression:'STORE' };
+    } else {
+        generateOptions = { compression:'STORE', type:'base64' };
 
         if (!process.browser) {
             generateOptions.type = 'nodebuffer';
           }
     }
 
-    return zip.generate(generateOptions);
+    return zip.generateAsync(generateOptions);
 };

--- a/src/zip.js
+++ b/src/zip.js
@@ -3,7 +3,7 @@ var write = require('./write'),
     prj = require('./prj'),
     JSZip = require('jszip');
 
-module.exports = function(gj, options) {
+module.exports = function(gj, options, generateOptions) {
 
     var zip = new JSZip(),
         layers = zip.folder(options && options.folder ? options.folder : 'layers');
@@ -15,7 +15,7 @@ module.exports = function(gj, options) {
                 // field definitions
                 l.properties,
                 // geometry type
-                l.type,
+                l.type, 
                 // geometries
                 l.geometries,
                 function(err, files) {
@@ -28,10 +28,14 @@ module.exports = function(gj, options) {
         }
     });
 
-    var generateOptions = { compression:'STORE' };
+    if (generateOptions){
+        generateOptions.compression = 'STORE';
+    }else{
+        generateOptions = { compression:'STORE' };
 
-    if (!process.browser) {
-      generateOptions.type = 'nodebuffer';
+        if (!process.browser) {
+            generateOptions.type = 'nodebuffer';
+          }
     }
 
     return zip.generate(generateOptions);


### PR DESCRIPTION
Currently it is not possible to configure the type used by zipjs. It is set to base64 by default. I added another parameter to zip in order to pass the options, which will be used zipjs.