### PR TITLE
Fixed extraction of polygon coordinates

### DIFF
--- a/src/geojson.js
+++ b/src/geojson.js
@@ -6,7 +6,7 @@ function justType(type, TYPE) {
     return function(gj) {
         var oftype = gj.features.filter(isType(type));
         return {
-            geometries: (TYPE === 'POLYGON' || TYPE === 'POLYLINE') ? [oftype.map(justCoords)] : oftype.map(justCoords),
+            geometries: oftype.map(justCoords),
             properties: oftype.map(justProps),
             type: TYPE
         };
@@ -14,13 +14,7 @@ function justType(type, TYPE) {
 }
 
 function justCoords(t) {
-    if (t.geometry.coordinates[0] !== undefined &&
-        t.geometry.coordinates[0][0] !== undefined &&
-        t.geometry.coordinates[0][0][0] !== undefined) {
-        return t.geometry.coordinates[0];
-    } else {
-        return t.geometry.coordinates;
-    }
+    return t.geometry.coordinates;
 }
 
 function justProps(t) {

--- a/src/poly.js
+++ b/src/poly.js
@@ -114,4 +114,3 @@ function justCoords(coords, l) {
         return coords;
     }
 }
-


### PR DESCRIPTION
This should fix #64 . Prior to this, for a given list of polygons from geojson write would have been called with one geometry (containing all other polygons) and n property objects, so only a single (multi-)geometry would be saved, but n entries in the .dbf.