### PR TITLE
Add option to zip files without folder

### DIFF
--- a/src/zip.js
+++ b/src/zip.js
@@ -8,6 +8,11 @@ module.exports = function(gj, options) {
     var zip = new JSZip(),
         layers = zip.folder(options && options.folder ? options.folder : 'layers');
 
+    // if options.folder is set to false, zip files without a folder
+    if (options && options.folder === false) {
+        layers = zip;
+    }
+    
     [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
         .forEach(function(l) {
         if (l.geometries.length && l.geometries[0].length) {


### PR DESCRIPTION
This addresses issue #70 

#### Problem
When zipping and downloading a shp file, jsZip creates a folder to put the files in. When the downloaded zip file is loaded into QGIS, it throws an error because it has a folder inside it. We want to have an option to zip the files without putting them in a folder.

#### Usage
Set `folder:false` in the options object that is passed into the zip function.

###### Example:
```
import { zip } from 'shp-write';

const geojson = {} // some valid geojson object

const options = {
  folder: false,
  types: {
    polylines: 'lines',
  }
}

const zipResults = zip(geojson, options);
```