### PR TITLE
Set the name of the ZIP file to the folder name, if a folder name has been specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ var shpwrite = require('shp-write');
 // (optional) set names for feature types and zipped folder
 var options = {
     folder: 'myshapes',
+    filename: 'mydownload',
     types: {
         point: 'mypoints',
         polygon: 'mypolygons',

--- a/src/download.js
+++ b/src/download.js
@@ -6,8 +6,8 @@ module.exports = function(gj, options) {
     var link = document.createElement('a');
     link.href = 'data:application/zip;base64,' + content;
     link.rel = 'noopener'
-    if (options && options.folder) {
-      link.download = options.folder + '.zip';
+    if (options && options.filename || options.folder) {
+      link.download = (options.filename || options.folder) + '.zip';
     }
     link.click();
     delete link;

--- a/src/download.js
+++ b/src/download.js
@@ -2,5 +2,13 @@ var zip = require('./zip');
 
 module.exports = function(gj, options) {
     var content = zip(gj, options);
-    location.href = 'data:application/zip;base64,' + content;
+
+    var link = document.createElement('a');
+    link.href = 'data:application/zip;base64,' + content;
+    link.rel = 'noopener'
+    if (options && options.folder) {
+      link.download = options.folder + '.zip';
+    }
+    link.click();
+    delete link;
 };


### PR DESCRIPTION
Currently the ZIP file has a random string as name, this PR sets the name of the ZIP file to the name of the folder (when specified) and allows the ZIP file to be named by the `filename` key in the options object.