### PR TITLE
deps, `options: filename`, multipolygon, `.d.ts`,  browser only downgrade (easy fix?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ Or in a browser
 - Tabular-style properties export with Shapefile's field name length limit
 - Uses jsZip for ZIP files, but [compression is buggy](https://github.com/Stuk/jszip/issues/53) so it uses STORE instead of DEFLATE.
 
-## Example
+## Minimal Example
 
 ```js
 var shpwrite = require("shp-write");
 
-// (optional) set names for feature types and zipped folder
+// (minimal) set names for feature types and zipped folder
 var options = {
   folder: "myshapes",
   filename: "mydownload",
+  outputType: "base64",
+  compression: "DEFLATE",
   types: {
     point: "mypoints",
     polygon: "mypolygons",
@@ -72,12 +74,6 @@ shpwrite.download(
 ```
 
 ## API
-
-### `download(geojson)`
-
-Given a [GeoJSON](http://geojson.org/) FeatureCollection as an object,
-converts convertible features into Shapefiles and triggers a download.
-
 ### `write(data, geometrytype, geometries, callback)`
 
 Given data, an array of objects for each row of data, geometry, the OGC standard
@@ -92,10 +88,22 @@ arrays, generate a shapfile and call the callback with `err` and an object with
 }
 ```
 
-### `zip(geojson)`
+### `zip(geojson, [options])`
 
 Generate a ArrayBuffer of a zipped shapefile, dbf, and prj, from a GeoJSON
 object.
+
+### DEPRECTEAD! May be removed in a future version
+### `download(geojson, [options])`
+
+Given a [GeoJSON](http://geojson.org/) FeatureCollection as an object,
+converts convertible features into Shapefiles and triggers a download. 
+
+The additional `options` parameter is passed to the underlying `zip` call. 
+
+This is now marked as deprecated because it applies to browsers only and the
+user should instead rely on an external library for this functionality like
+`file-saver` or `downloadjs`
 
 ## Other Implementations
 

--- a/README.md
+++ b/README.md
@@ -18,52 +18,56 @@ Or in a browser
 
 ## Caveats
 
-* Requires a capable fancy modern browser with [Typed Arrays](http://caniuse.com/#feat=typedarrays)
+- Requires a capable fancy modern browser with [Typed Arrays](http://caniuse.com/#feat=typedarrays)
   support
-* Geometries: Point, LineString, Polygon, MultiLineString, MultiPolygon
-* Tabular-style properties export with Shapefile's field name length limit
-* Uses jsZip for ZIP files, but [compression is buggy](https://github.com/Stuk/jszip/issues/53) so it uses STORE instead of DEFLATE.
+- Geometries: Point, LineString, Polygon, MultiLineString, MultiPolygon
+- Tabular-style properties export with Shapefile's field name length limit
+- Uses jsZip for ZIP files, but [compression is buggy](https://github.com/Stuk/jszip/issues/53) so it uses STORE instead of DEFLATE.
 
 ## Example
 
 ```js
-var shpwrite = require('shp-write');
+var shpwrite = require("shp-write");
 
 // (optional) set names for feature types and zipped folder
 var options = {
-    folder: 'myshapes',
-    types: {
-        point: 'mypoints',
-        polygon: 'mypolygons',
-        line: 'mylines'
-    }
-}
+  folder: "myshapes",
+  filename: "mydownload",
+  types: {
+    point: "mypoints",
+    polygon: "mypolygons",
+    line: "mylines",
+  },
+};
 // a GeoJSON bridge for features
-shpwrite.download({
-    type: 'FeatureCollection',
+shpwrite.download(
+  {
+    type: "FeatureCollection",
     features: [
-        {
-            type: 'Feature',
-            geometry: {
-                type: 'Point',
-                coordinates: [0, 0]
-            },
-            properties: {
-                name: 'Foo'
-            }
+      {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [0, 0],
         },
-        {
-            type: 'Feature',
-            geometry: {
-                type: 'Point',
-                coordinates: [0, 10]
-            },
-            properties: {
-                name: 'Bar'
-            }
-        }
-    ]
-}, options);
+        properties: {
+          name: "Foo",
+        },
+      },
+      {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [0, 10],
+        },
+        properties: {
+          name: "Bar",
+        },
+      },
+    ],
+  },
+  options
+);
 // triggers a download of a zip file with shapefiles contained within.
 ```
 
@@ -95,12 +99,12 @@ object.
 
 ## Other Implementations
 
-* https://code.google.com/p/pyshp/
+- https://code.google.com/p/pyshp/
 
 ## Reference
 
-* http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
+- http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
 
 ## Contributors
 
-* Nick Baugh <niftylettuce@gmail.com>
+- Nick Baugh <niftylettuce@gmail.com>

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -17,18 +17,50 @@ declare module "shp-write" {
   }
 
   export interface DownloadOptions {
-    folder: string;
+    folder?: string;
     filename?: string;
     types: {
-      point: string;
-      polygon: string;
-      line: string;
+      point?: string;
+      polygon?: string;
+      line?: string;
+      multipolygon?: string;
+      multiline?: string;
     };
   }
 
+  type Compression = 'STORE' | 'DEFLATE';
+  interface OutputByType {
+    base64: string;
+    string: string;
+    text: string;
+    binarystring: string;
+    array: number[];
+    uint8array: Uint8Array;
+    arraybuffer: ArrayBuffer;
+    blob: Blob;
+    nodebuffer: Buffer;
+    stream: ReadableStream;
+  }
+  type OutputType = keyof OutputByType;
+
+  export interface ZipOptions {
+    compression: Compression,
+    outputType: OutputType
+  }
+
+  DEFAULT_ZIP_OPTIONS = {
+    compression: 'STORE',
+    outputType: 'base64',
+    types: {
+      point: "mypoints",
+      polygon: "mypolygons",
+      line: "mylines",
+    },
+  };
+
   export function download(
     geojson: GeoJSON.FeatureCollection,
-    options?: DownloadOptions
+    options?: DownloadOptions & ZipOptions = DEFAULT_ZIP_OPTIONS
   ): void;
 
   export function write(
@@ -45,5 +77,8 @@ declare module "shp-write" {
     ) => void
   ): void;
 
-  export function zip(geojson: GeoJSON.FeatureCollection): void;
+  export function zip<T extends OutputType>(
+    geojson: GeoJSON.FeatureCollection,
+    options: DownloadOptions & ZipOptions = DEFAULT_ZIP_OPTIONS,
+    stream = false): Promise<OutputByType[T]>;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,49 @@
+declare module "shp-write" {
+  export enum OGCGeometry {
+    NULL,
+    POINT,
+    POLYLINE,
+    POLYGON,
+    MULTIPOINT,
+    POINTZ,
+    POLYLINEZ,
+    POLYGONZ,
+    MULTIPOINTZ,
+    POINTM,
+    POLYLINEM,
+    POLYGONM,
+    MULTIPOINTM,
+    MULTIPATCH,
+  }
+
+  export interface DownloadOptions {
+    folder: string;
+    filename?: string;
+    types: {
+      point: string;
+      polygon: string;
+      line: string;
+    };
+  }
+
+  export function download(
+    geojson: GeoJSON.FeatureCollection,
+    options?: DownloadOptions
+  ): void;
+
+  export function write(
+    data: Array<object>,
+    geometrytype: OGCGeometry,
+    geometries: Array<object>,
+    callback: (
+      err: any,
+      data: {
+        shp: any;
+        shx: any;
+        dbf: any;
+      }
+    ) => void
+  ): void;
+
+  export function zip(geojson: GeoJSON.FeatureCollection): void;
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,3 @@
+module.exports.download = require("../src/download");
+module.exports.write = require("../src/write");
+module.exports.zip = require("../src/zip");

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-module.exports.download = require('./src/download')
-module.exports.write = require('./src/write')
-module.exports.zip = require('./src/zip')

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "url": "https://github.com/mapbox/shp-write/issues"
   },
   "dependencies": {
-    "dbf": "0.1.4",
-    "jszip": "2.5.0"
+    "dbf": "0.2.0",
+    "jszip": "3.6.0"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "git://github.com/mapbox/shp-write.git"
   },
   "files": [
-    "index.js",
+    "dist/index.js",
+    "dist/index.d.ts",
     "src",
     "shpwrite.js"
   ],

--- a/package.json
+++ b/package.json
@@ -25,19 +25,14 @@
     "js"
   ],
   "author": "Tom MacWright",
-  "contributors": [
-    {
-      "name": "Nick Baugh",
-      "email": "niftylettuce@gmail.com"
-    }
-  ],
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/mapbox/shp-write/issues"
   },
   "dependencies": {
     "dbf": "0.2.0",
-    "jszip": "3.6.0"
+    "jszip": "3.6.0",
+    "file-saver": "2.0.5"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "shp-write",
   "version": "0.3.2",
   "description": "write shapefiles from pure javascript",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "mocha -R spec",
     "prepublish": "npm run make",

--- a/src/download.js
+++ b/src/download.js
@@ -9,5 +9,7 @@ module.exports = function (gj, options) {
     link.download = (options.filename || options.folder) + ".zip";
   }
   link.click();
-  delete link;
+
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(link.href);
 };

--- a/src/download.js
+++ b/src/download.js
@@ -9,7 +9,5 @@ module.exports = function (gj, options) {
     link.download = (options.filename || options.folder) + ".zip";
   }
   link.click();
-
-  document.body.removeChild(link);
   window.URL.revokeObjectURL(link.href);
 };

--- a/src/download.js
+++ b/src/download.js
@@ -1,6 +1,13 @@
-var zip = require('./zip');
+var zip = require("./zip");
 
-module.exports = function(gj, options) {
-    var content = zip(gj, options);
-    location.href = 'data:application/zip;base64,' + content;
+module.exports = function (gj, options) {
+  var content = zip(gj, options);
+  var link = document.createElement("a");
+  link.href = "data:application/zip;base64," + content;
+  link.rel = "noopener";
+  if ((options && options.filename) || options.folder) {
+    link.download = (options.filename || options.folder) + ".zip";
+  }
+  link.click();
+  delete link;
 };

--- a/src/download.js
+++ b/src/download.js
@@ -1,7 +1,7 @@
 var zip = require("./zip");
 
-module.exports = function (gj, options) {
-  var content = zip(gj, options);
+module.exports = async function (gj, options) {
+  var content = await zip(gj, options);
   var link = document.createElement("a");
   link.href = "data:application/zip;base64," + content;
   link.rel = "noopener";

--- a/src/download.js
+++ b/src/download.js
@@ -1,13 +1,28 @@
-var zip = require("./zip");
+var zip = require('./zip');
+var saveAs = require("file-saver").saveAs;
 
-module.exports = async function (gj, options) {
-  var content = await zip(gj, options);
-  var link = document.createElement("a");
-  link.href = "data:application/zip;base64," + content;
-  link.rel = "noopener";
-  if ((options && options.filename) || options.folder) {
-    link.download = (options.filename || options.folder) + ".zip";
+/**
+ * @deprecated may be removed in a future version, please use an external 
+ * download library
+ */
+module.exports = function (
+    gj, 
+    options = {
+      compression: 'STORE',
+      outputType: 'base64',
+      types: {
+        point: "mypoints",
+        polygon: "mypolygons",
+        line: "mylines",
+      },
+    },
+) {
+  let filename = 'download';
+
+  // since we only need a single filename object, we can use either the folder or
+  // filename, depending on what was passed in
+  if (options && (options.filename || options.folder)) {
+    filename = (options.filename || options.folder);
   }
-  link.click();
-  window.URL.revokeObjectURL(link.href);
+  zip(gj, options).then(function (blob) { saveAs(blob, filename + '.zip'); });
 };

--- a/src/geojson.js
+++ b/src/geojson.js
@@ -1,32 +1,35 @@
-module.exports.point = justType('Point', 'POINT');
-module.exports.line = justType('LineString', 'POLYLINE');
-module.exports.polygon = justType('Polygon', 'POLYGON');
+module.exports.point = justType("Point", "POINT");
+module.exports.line = justType("LineString", "POLYLINE");
+module.exports.multiline = justType("MultiLineString", "POLYLINE");
+module.exports.polygon = justType("Polygon", "POLYGON");
+module.exports.multipolygon = justType("MultiPolygon", "POLYGON");
 
 function justType(type, TYPE) {
-    return function(gj) {
-        var oftype = gj.features.filter(isType(type));
-        return {
-            geometries: (TYPE === 'POLYGON' || TYPE === 'POLYLINE') ? [oftype.map(justCoords)] : oftype.map(justCoords),
-            properties: oftype.map(justProps),
-            type: TYPE
-        };
+  return function (gj) {
+    var oftype = gj.features.filter(isType(type));
+    return {
+      geometries: oftype.map(justCoords),
+      properties: oftype.map(justProps),
+      type: TYPE,
     };
+  };
 }
 
 function justCoords(t) {
-    if (t.geometry.coordinates[0] !== undefined &&
-        t.geometry.coordinates[0][0] !== undefined &&
-        t.geometry.coordinates[0][0][0] !== undefined) {
-        return t.geometry.coordinates[0];
-    } else {
-        return t.geometry.coordinates;
-    }
+  return t.geometry.coordinates;
 }
 
 function justProps(t) {
-    return t.properties;
+  return t.properties;
 }
 
 function isType(t) {
-    return function(f) { return f.geometry.type === t; };
+  if (Array.isArray(t))
+    return function (f) {
+      return t.includes(f.geometry.type);
+    };
+  else
+    return function (f) {
+      return f.geometry.type === t;
+    };
 }

--- a/src/points.js
+++ b/src/points.js
@@ -11,7 +11,7 @@ module.exports.write = function writePoints(coordinates, extent, shpView, shxVie
         // HEADER
         // 4 record number
         // 4 content length in 16-bit words (20/2)
-        shpView.setInt32(shpI, i);
+        shpView.setInt32(shpI, i + 1);
         shpView.setInt32(shpI + 4, 10);
 
         // record

--- a/src/zip.js
+++ b/src/zip.js
@@ -3,7 +3,19 @@ var write = require("./write"),
   prj = require("./prj"),
   JSZip = require("jszip");
 
-module.exports = function (gj, options, stream = false) {
+module.exports = function (
+  gj,
+  options = {
+    compression: 'STORE',
+    outputType: 'base64',
+    types: {
+      point: "mypoints",
+      polygon: "mypolygons",
+      line: "mylines",
+    },
+  },
+  stream = false
+) {
   var zip = new JSZip(),
     layers = zip.folder(options && options.folder ? options.folder : "layers");
 
@@ -36,14 +48,18 @@ module.exports = function (gj, options, stream = false) {
     }
   });
 
-  var generateOptions = { type: "base64", compression: "STORE" };
+  var generateOptions = {};
+  if (options && options.outputType) {
+    generateOptions.type = options.outputType;
+  }
 
-  // Our implementation will DEFINITELY be in the browser for now.
-  // if (!process.browser) {
-  //   generateOptions.type = "nodebuffer";
-  // }
+  if (options && options.compresssion) {
+    generateOptions.compression = options.compression;
+  }
 
-  if (stream)
+  if (stream) {
     return zip.generateNodeStream({ ...generateOptions, streamFiles: true });
-  else return zip.generateAsync(generateOptions);
+  }
+
+  return zip.generateAsync(generateOptions);
 };

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,38 +1,48 @@
-var write = require('./write'),
-    geojson = require('./geojson'),
-    prj = require('./prj'),
-    JSZip = require('jszip');
+var write = require("./write"),
+  geojson = require("./geojson"),
+  prj = require("./prj"),
+  JSZip = require("jszip");
 
-module.exports = function(gj, options) {
+module.exports = function (gj, options, stream = false) {
+  var zip = new JSZip(),
+    layers = zip.folder(options && options.folder ? options.folder : "layers");
 
-    var zip = new JSZip(),
-        layers = zip.folder(options && options.folder ? options.folder : 'layers');
-
-    [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
-        .forEach(function(l) {
-        if (l.geometries.length && l.geometries[0].length) {
-            write(
-                // field definitions
-                l.properties,
-                // geometry type
-                l.type,
-                // geometries
-                l.geometries,
-                function(err, files) {
-                    var fileName = options && options.types[l.type.toLowerCase()] ? options.types[l.type.toLowerCase()] : l.type;
-                    layers.file(fileName + '.shp', files.shp.buffer, { binary: true });
-                    layers.file(fileName + '.shx', files.shx.buffer, { binary: true });
-                    layers.file(fileName + '.dbf', files.dbf.buffer, { binary: true });
-                    layers.file(fileName + '.prj', prj);
-                });
+  [
+    geojson.point(gj),
+    geojson.line(gj),
+    geojson.polygon(gj),
+    geojson.multipolygon(gj),
+    geojson.multiline(gj),
+  ].forEach(function (l) {
+    if (l.geometries.length && l.geometries[0].length) {
+      write(
+        // field definitions
+        l.properties,
+        // geometry type
+        l.type,
+        // geometries
+        l.geometries,
+        function (err, files) {
+          var fileName =
+            options && options.types[l.type.toLowerCase()]
+              ? options.types[l.type.toLowerCase()]
+              : l.type;
+          layers.file(fileName + ".shp", files.shp.buffer, { binary: true });
+          layers.file(fileName + ".shx", files.shx.buffer, { binary: true });
+          layers.file(fileName + ".dbf", files.dbf.buffer, { binary: true });
+          layers.file(fileName + ".prj", prj);
         }
-    });
-
-    var generateOptions = { compression:'STORE' };
-
-    if (!process.browser) {
-      generateOptions.type = 'nodebuffer';
+      );
     }
+  });
 
-    return zip.generate(generateOptions);
+  var generateOptions = { compression: "STORE" };
+
+  if (!process.browser) {
+    generateOptions.type = "nodebuffer";
+  }
+
+  if (stream)
+    return zip.generateNodeStream({ ...generateOptions, streamFiles: true });
+  else return zip.generateAsync(generateOptions);
 };

--- a/src/zip.js
+++ b/src/zip.js
@@ -36,7 +36,7 @@ module.exports = function (gj, options, stream = false) {
     }
   });
 
-  var generateOptions = { compression: "STORE" };
+  var generateOptions = { type: "base64", compression: "STORE" };
 
   // Our implementation will DEFINITELY be in the browser for now.
   // if (!process.browser) {

--- a/src/zip.js
+++ b/src/zip.js
@@ -38,9 +38,10 @@ module.exports = function (gj, options, stream = false) {
 
   var generateOptions = { compression: "STORE" };
 
-  if (!process.browser) {
-    generateOptions.type = "nodebuffer";
-  }
+  // Our implementation will DEFINITELY be in the browser for now.
+  // if (!process.browser) {
+  //   generateOptions.type = "nodebuffer";
+  // }
 
   if (stream)
     return zip.generateNodeStream({ ...generateOptions, streamFiles: true });


### PR DESCRIPTION
closes #68
closes #73 
closes #74
closes #84
closes #88 
closes #90
opens https://github.com/mapbox/shp-write/issues/97

I guess my Prettier reformatted all the code, so it is hard to see my exact changes to the codebase. I do not have the time to change it to only show the pure diff.

install with: 
```
npm i https://github.com/Agriculture-Intelligence/shp-write.git
```