### PR TITLE
upgrade version to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shp-write",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "write shapefiles from pure javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Increased tag to 0.4.0. A new release can be made.@sheindel 

The goal is for package.json dependency line say: `shp-write: 0.4.0`

Issues that previous PR did not close: 
fix #66, fix #57, fix #59
closes #56, closes #72, closes #75