### PR TITLE
v0.4.0 on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shp-write",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "write shapefiles from pure javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Increased tag to 0.4.0. A new release can be made .@sheindel

The goal is for package.json dependency line say: shp-write: 0.4.0

Issues that previous PR did not close:
fix https://github.com/mapbox/shp-write/issues/66, fix https://github.com/mapbox/shp-write/issues/57, fix https://github.com/mapbox/shp-write/issues/59
closes https://github.com/mapbox/shp-write/pull/56, closes https://github.com/mapbox/shp-write/pull/72, closes https://github.com/mapbox/shp-write/pull/75