### PR TITLE
Readme cleanup, final API state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 shpwrite.js
+node_modules
+example/*.dbf
+example/*.shp
+example/*.shx
+yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+
+
+<a name="0.4.0"></a>
+## [0.4.0](https://github.com/mapbox/shp-write/compare/v0.3.2...v0.4.0) (2023-08-20)
+
+* Upgrade JSZip and dbf dependencies
+* Added types
+* Added options for compression and type output to `zip` and `download`
+* Added deprecation warning to `download` (not needed for this library)
+* 
+
 <a name="0.3.2"></a>
 ## [0.3.2](https://github.com/mapbox/shp-write/compare/v0.3.1...v0.3.2) (2016-12-06)
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,8 @@ Or in a browser
 ```js
 var shpwrite = require("shp-write");
 
-// (minimal) set names for feature types
-var options = {
-  types: {
-    point: "mypoints",
-    polygon: "mypolygons",
-    line: "mylines",
-  },
-};
 // a GeoJSON bridge for features
-shpwrite.download(
+const zipData = shpwrite.zip(
   {
     type: "FeatureCollection",
     features: [
@@ -63,10 +55,56 @@ shpwrite.download(
         },
       },
     ],
-  },
-  options
+  }
 );
-// triggers a download of a zip file with shapefiles contained within.
+
+```
+
+## Options Example
+
+```js
+var shpwrite = require("shp-write");
+
+const options = {
+  folder: "my_internal_shapes_folder",
+  filename: "my_zip_filename",
+  outputType: "blob",
+  compression: "DEFLATE",
+  types: {
+    point: "mypoints",
+    polygon: "mypolygons",
+    line: "mylines",
+  },
+};
+
+// a GeoJSON bridge for features
+const zipData = shpwrite.zip(
+  {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [0, 0],
+        },
+        properties: {
+          name: "Foo",
+        },
+      },
+      {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [0, 10],
+        },
+        properties: {
+          name: "Bar",
+        },
+      },
+    ],
+  }
+);
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ const zipData = shpwrite.zip(
         },
       },
     ],
-  }
+  },
+  options
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,8 @@ Or in a browser
 ```js
 var shpwrite = require("shp-write");
 
-// (minimal) set names for feature types and zipped folder
+// (minimal) set names for feature types
 var options = {
-  folder: "myshapes",
-  filename: "mydownload",
-  outputType: "base64",
-  compression: "DEFLATE",
   types: {
     point: "mypoints",
     polygon: "mypolygons",

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -19,7 +19,7 @@ declare module "shp-write" {
   export interface DownloadOptions {
     folder?: string;
     filename?: string;
-    types: {
+    types?: {
       point?: string;
       polygon?: string;
       line?: string;
@@ -48,19 +48,9 @@ declare module "shp-write" {
     outputType: OutputType
   }
 
-  DEFAULT_ZIP_OPTIONS = {
-    compression: 'STORE',
-    outputType: 'base64',
-    types: {
-      point: "mypoints",
-      polygon: "mypolygons",
-      line: "mylines",
-    },
-  };
-
   export function download(
     geojson: GeoJSON.FeatureCollection,
-    options?: DownloadOptions & ZipOptions = DEFAULT_ZIP_OPTIONS
+    options?: DownloadOptions & ZipOptions = {}
   ): void;
 
   export function write(
@@ -79,6 +69,6 @@ declare module "shp-write" {
 
   export function zip<T extends OutputType>(
     geojson: GeoJSON.FeatureCollection,
-    options: DownloadOptions & ZipOptions = DEFAULT_ZIP_OPTIONS,
+    options: DownloadOptions & ZipOptions = {},
     stream = false): Promise<OutputByType[T]>;
 }

--- a/example/point.js
+++ b/example/point.js
@@ -26,7 +26,7 @@ function finish(err, files) {
 }
 
 function toBuffer(ab) {
-    var buffer = new Buffer(ab.byteLength),
+    var buffer = Buffer.alloc(ab.byteLength),
         view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) { buffer[i] = view[i]; }
     return buffer;

--- a/example/test.js
+++ b/example/test.js
@@ -27,7 +27,7 @@ function finish(err, files) {
 }
 
 function toBuffer(ab) {
-    var buffer = new Buffer(ab.byteLength),
+    var buffer = Buffer.alloc(ab.byteLength),
         view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) { buffer[i] = view[i]; }
     return buffer;

--- a/example/test_linestring.js
+++ b/example/test_linestring.js
@@ -24,7 +24,7 @@ function finish(err, files) {
 }
 
 function toBuffer(ab) {
-    var buffer = new Buffer(ab.byteLength),
+    var buffer = Buffer.alloc(ab.byteLength),
         view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) { buffer[i] = view[i]; }
     return buffer;

--- a/example/test_multiple_poly.js
+++ b/example/test_multiple_poly.js
@@ -22,7 +22,7 @@ function finish(err, files) {
 }
 
 function toBuffer(ab) {
-    var buffer = new Buffer(ab.byteLength),
+    var buffer = Buffer.alloc(ab.byteLength),
         view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) { buffer[i] = view[i]; }
     return buffer;

--- a/example/test_polygon.js
+++ b/example/test_polygon.js
@@ -25,7 +25,7 @@ function finish(err, files) {
 }
 
 function toBuffer(ab) {
-    var buffer = new Buffer(ab.byteLength),
+    var buffer = Buffer.alloc(ab.byteLength),
         view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) { buffer[i] = view[i]; }
     return buffer;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shp-write",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "write shapefiles from pure javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/download.js
+++ b/src/download.js
@@ -5,18 +5,7 @@ var saveAs = require("file-saver").saveAs;
  * @deprecated may be removed in a future version, please use an external 
  * download library
  */
-module.exports = function (
-    gj, 
-    options = {
-      compression: 'STORE',
-      outputType: 'base64',
-      types: {
-        point: "mypoints",
-        polygon: "mypolygons",
-        line: "mylines",
-      },
-    },
-) {
+module.exports = function (gj, options) {
   let filename = 'download';
 
   // since we only need a single filename object, we can use either the folder or

--- a/src/zip.js
+++ b/src/zip.js
@@ -11,7 +11,7 @@ module.exports = function (
   let zip = new JSZip();
   let zipTarget = zip;
   if (options && options.folder) {
-    zipTarget = zip.folder(options && options.folder ? options.folder : "layers");
+    zipTarget = zip.folder(options.folder);
   }
 
   [

--- a/src/zip.js
+++ b/src/zip.js
@@ -31,7 +31,7 @@ module.exports = function (
         l.geometries,
         function (err, files) {
           var fileName =
-            options && options.types[l.type.toLowerCase()]
+            options && options.types && options.types[l.type.toLowerCase()]
               ? options.types[l.type.toLowerCase()]
               : l.type;
           zipTarget.file(fileName + ".shp", files.shp.buffer, { binary: true });


### PR DESCRIPTION
- Fixed some issues with backwards compatibility with API surface by better handling defaults for zip options. 
- Allow root zip file outputs
- Made API truly no-options capable (fixed no types bug)
- Updated README
- Updated version
