### PR TITLE
Fix broken types in index.d.ts

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -68,6 +68,6 @@ declare module "@mapbox/shp-write" {
 
   export function zip<T extends OutputType>(
     geojson: GeoJSON.FeatureCollection,
-    options: DownloadOptions & ZipOptions,
-    stream: boolean): Promise<OutputByType[T]>;
+    options?: DownloadOptions & ZipOptions,
+    stream?: boolean): Promise<OutputByType[T]>;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,20 +1,19 @@
 declare module "@mapbox/shp-write" {
-  export enum OGCGeometry {
-    NULL,
-    POINT,
-    POLYLINE,
-    POLYGON,
-    MULTIPOINT,
-    POINTZ,
-    POLYLINEZ,
-    POLYGONZ,
-    MULTIPOINTZ,
-    POINTM,
-    POLYLINEM,
-    POLYGONM,
-    MULTIPOINTM,
-    MULTIPATCH,
-  }
+  export type OGCGeometry =
+    'NULL' |
+    'POINT' |
+    'POLYLINE' |
+    'POLYGON' |
+    'MULTIPOINT' |
+    'POINTZ' |
+    'POLYLINEZ' |
+    'POLYGONZ' |
+    'MULTIPOINTZ' |
+    'POINTM' |
+    'POLYLINEM' |
+    'POLYGONM' |
+    'MULTIPOINTM' |
+    'MULTIPATCH';
 
   export interface DownloadOptions {
     folder?: string;
@@ -50,7 +49,7 @@ declare module "@mapbox/shp-write" {
 
   export function download(
     geojson: GeoJSON.FeatureCollection,
-    options?: DownloadOptions & ZipOptions = {}
+    options?: DownloadOptions & ZipOptions
   ): void;
 
   export function write(
@@ -69,6 +68,6 @@ declare module "@mapbox/shp-write" {
 
   export function zip<T extends OutputType>(
     geojson: GeoJSON.FeatureCollection,
-    options: DownloadOptions & ZipOptions = {},
-    stream = false): Promise<OutputByType[T]>;
+    options: DownloadOptions & ZipOptions,
+    stream: boolean): Promise<OutputByType[T]>;
 }


### PR DESCRIPTION
- Fixing the enum: In this case the enum is not really an enum is is a set of strings that map to the properties of a JS object. - Fixes #103 
- Removing the default values. - Fixes #104 
