### PR TITLE
117 Bugfix: Multiple LineStrings should map to multiple features in output

### DIFF
--- a/src/geojson.js
+++ b/src/geojson.js
@@ -14,7 +14,7 @@ function justType(gjType, shpType) {
   return function (gj) {
     var oftype = gj.features.filter(isType(gjType));
     return {
-      geometries: shpType === 'POLYLINE' ? [oftype.map(justCoords)] : oftype.map(justCoords),
+      geometries: shpType === 'POLYLINE' ? oftype.map(l => [justCoords(l)]) : oftype.map(justCoords),
       properties: oftype.map(justProps),
       type: shpType,
     };


### PR DESCRIPTION
Addresses https://github.com/mapbox/shp-write/issues/117

Use the same solution proposed in this issue link. The current code incorrectly was combining all lines into a single feature. With this change, each geojson LineString is its own feature in the output .shp file.

Likely this also address https://github.com/mapbox/shp-write/issues/127, but i haven't verified it.
