### PR TITLE
121 Bugfix properly combine multilinestring multipolygon when zipping

### DIFF
--- a/src/zip.js
+++ b/src/zip.js
@@ -18,25 +18,28 @@ module.exports = function (
   var prj = (options && options.prj) ? options.prj : defaultPrj;
 
   [
-    geojson.point(gj),
-    geojson.line(gj),
-    geojson.polygon(gj),
-    geojson.multipolygon(gj),
-    geojson.multiline(gj),
-  ].forEach(function (l) {
-    if (l.geometries.length && l.geometries[0].length) {
-      write(
+    [geojson.point(gj)],
+    [geojson.line(gj), geojson.multiline(gj)],
+    [geojson.polygon(gj), geojson.multipolygon(gj)],
+    ].forEach(function (l) {
+    if ((l[0].geometries.length && l[0].geometries[0].length) || l[1] && l[1].geometries.length && l[1].geometries[0].length) {
+ 
+        const properties = l.flatMap(l => l.properties);
+        const geometries = l.flatMap(l => l.geometries);
+        const type = l[0].type;
+ 
+        write(
         // field definitions
-        l.properties,
+        properties,
         // geometry type
-        l.type,
+        l[0].type,
         // geometries
-        l.geometries,
+        geometries,
         function (err, files) {
           var fileName =
-            options && options.types && options.types[l.type.toLowerCase()]
-              ? options.types[l.type.toLowerCase()]
-              : l.type;
+            options && options.types && options.types[type.toLowerCase()]
+              ? options.types[type.toLowerCase()]
+              : type;
           zipTarget.file(fileName + ".shp", files.shp.buffer, { binary: true });
           zipTarget.file(fileName + ".shx", files.shx.buffer, { binary: true });
           zipTarget.file(fileName + ".dbf", files.dbf.buffer, { binary: true });


### PR DESCRIPTION
Addresses https://github.com/mapbox/shp-write/issues/121

Zip currently iterates through point, linestring, multilinestring, polygon, multipolygon and outputs them with one file each named as point, polyline, or polygon. (5 total, 3 unique names)

This causes an issue if you have linestring+multilinestring or polygon+multipolygon. They end up in separate files, but with the same file name, so they overwrite each other in the output and you lose one of them.

This change instead combines them into a single file. For shapefiles, which do not differentiate in file type for linestring/multilinestring or polygon/multipolygon, this makes sense.

The output after this change will produce at most 3 different files in the zip: one for point, one for line+multilinestring, one for polygon+multipolygon.

Note: this does not address multipoints, which are currently not handled properly by the library either.