### PR TITLE
Added codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @mapbox/docs


### PR DESCRIPTION
This PR adds @mapbox/docs as the CODEOWNERS of this repo as this is a direct dependency of [GeoJSON.io](https://GeoJSON.io)